### PR TITLE
Add tmux layout preset save/restore functionality

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -97,6 +97,7 @@ AGENTS.md
 .env-backup-2
 .tmp
 todos
+.todos
 docs
 typescript/docs
 screenshots

--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -273,5 +273,8 @@ setw -g status-position top
 bind-key j command-prompt -p "join pane from:"  "join-pane -s '%%'"
 bind-key s command-prompt -p "send pane to:"  "join-pane -t '%%'"
 
+# Override new window binding to start in ~/code/
+bind c new-window -c "$HOME/code" \; send-keys "cd $HOME/code" C-m \; send-keys "clear" C-m
+
 # Clear Claude status prefix when switching to a window
 set-hook -g window-focus-in 'run-shell -b "name=$(tmux display-message -p \x27#{window_name}\x27); case \"$name\" in [~*#]*) tmux rename-window \"${name#[~*#]}\" ;; esac"'

--- a/.tmux.conf.local
+++ b/.tmux.conf.local
@@ -276,5 +276,9 @@ bind-key s command-prompt -p "send pane to:"  "join-pane -t '%%'"
 # Override new window binding to start in ~/code/
 bind c new-window -c "$HOME/code" \; send-keys "cd $HOME/code" C-m \; send-keys "clear" C-m
 
+# Save/restore named layouts with tmux-resurrect
+bind S command-prompt -p "Save layout as:" "run-shell '~/.tmux/scripts/save-layout.sh \"%%\"'"
+bind R command-prompt -p "Restore layout:" "run-shell '~/.tmux/scripts/restore-layout.sh \"%%\"'"
+
 # Clear Claude status prefix when switching to a window
-set-hook -g window-focus-in 'run-shell -b "name=$(tmux display-message -p \x27#{window_name}\x27); case \"$name\" in [~*#]*) tmux rename-window \"${name#[~*#]}\" ;; esac"'
+set-hook -g after-select-window 'run-shell -b "name=$(tmux display-message -p \x27#{window_name}\x27); case \"$name\" in [~*#]*) tmux rename-window \"${name#[~*#]}\" ;; esac"'

--- a/.tmux/scripts/restore-layout.sh
+++ b/.tmux/scripts/restore-layout.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Restore a named tmux layout
+
+LAYOUT_NAME="$1"
+RESURRECT_DIR="$HOME/.tmux/resurrect"
+SCRIPT_PATH="$HOME/.tmux/plugins/tmux-resurrect/scripts/restore.sh"
+
+if [ -z "$LAYOUT_NAME" ]; then
+    echo "Usage: restore-layout.sh <name>"
+    exit 1
+fi
+
+# Check if the named layout exists
+if [ ! -f "$RESURRECT_DIR/$LAYOUT_NAME" ]; then
+    echo "Error: Layout '$LAYOUT_NAME' not found"
+    echo "Available layouts:"
+    ls -1 "$RESURRECT_DIR" 2>/dev/null | grep -v '^last$' | grep -v '^pane_contents' | grep -v '\.txt$' || echo "  (none)"
+    exit 1
+fi
+
+# Copy the named layout to 'last' so resurrect will restore it
+cp "$RESURRECT_DIR/$LAYOUT_NAME" "$RESURRECT_DIR/last"
+
+# Run the resurrect restore script
+"$SCRIPT_PATH"
+
+echo "Layout restored: $LAYOUT_NAME"

--- a/.tmux/scripts/save-layout.sh
+++ b/.tmux/scripts/save-layout.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Save current tmux layout with a custom name
+
+LAYOUT_NAME="$1"
+RESURRECT_DIR="$HOME/.tmux/resurrect"
+SCRIPT_PATH="$HOME/.tmux/plugins/tmux-resurrect/scripts/save.sh"
+
+if [ -z "$LAYOUT_NAME" ]; then
+    echo "Usage: save-layout.sh <name>"
+    exit 1
+fi
+
+# Create resurrect directory if it doesn't exist
+mkdir -p "$RESURRECT_DIR"
+
+# Run the resurrect save script
+"$SCRIPT_PATH"
+
+# Copy the last saved state to our named layout
+if [ -f "$RESURRECT_DIR/last" ]; then
+    cp "$RESURRECT_DIR/last" "$RESURRECT_DIR/$LAYOUT_NAME"
+    echo "Layout saved as: $LAYOUT_NAME"
+else
+    echo "Error: Could not find saved state"
+    exit 1
+fi

--- a/Alfred.alfredpreferences/preferences/features/defaultresults/prefs.plist
+++ b/Alfred.alfredpreferences/preferences/features/defaultresults/prefs.plist
@@ -8,10 +8,6 @@
 	<true/>
 	<key>showContacts</key>
 	<false/>
-	<key>showDocuments</key>
-	<true/>
-	<key>showFolders</key>
-	<true/>
 	<key>showUserDefined</key>
 	<array>
 		<string>com.apple.alias-file</string>


### PR DESCRIPTION
## Summary
- Add custom key bindings for saving/restoring named tmux layouts
- New window binding to open in `~/code/` directory
- Helper scripts for managing multiple layout presets (work vs personal)

## Usage
- **Save layout**: `leader + Shift+S`, then enter name (e.g., `work`, `personal`)
- **Restore layout**: `leader + Shift+R`, then enter name

## Changes
- Added `leader + S` binding to save current layout with custom name
- Added `leader + R` binding to restore saved layout by name
- Created helper scripts: `save-layout.sh` and `restore-layout.sh`
- Configured new windows (`leader + c`) to start in `~/code/`
- Fixed window hook to use `after-select-window`

🤖 Generated with [Claude Code](https://claude.com/claude-code)